### PR TITLE
create scanner and iterator to modularize exec and add timestamp type check

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -2290,7 +2290,8 @@ class Analyzer(
   object ResolveMergeAsof extends Rule[LogicalPlan] {
     override def apply(plan: LogicalPlan): LogicalPlan = plan match {
       case m @ MergeAsOf(left, right, leftOn, rightOn, leftBy, rightBy, tolerance, exact)
-        if left.resolved && right.resolved && m.duplicateResolved => {
+        // Removed m.duplicateResolved to allow self joins but should allow self joins regardless
+        if left.resolved && right.resolved => {
           val lUniqueOutput = left.output.filterNot(att => leftBy == att || leftOn == att)
           val rUniqueOutput = right.output.filterNot(att => rightBy == att || rightOn == att)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.catalyst.plans.logical
 
 import scala.concurrent.duration.Duration
 
+import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalog.v2.{Identifier, TableCatalog}
 import org.apache.spark.sql.catalog.v2.expressions.Transform
 import org.apache.spark.sql.catalyst.AliasIdentifier
@@ -392,6 +393,15 @@ object MergeAsOf {
     } else {
       Long.MaxValue
     }
+
+    if (leftOn.dataType != TimestampType) {
+      throw new AnalysisException("cannot resolve due to data type mismatch: " +
+        s"${leftOn.dataType} should be a TimestampType")
+    } else if (rightOn.dataType != TimestampType) {
+      throw new AnalysisException("cannot resolve due to data type mismatch: " +
+        s"${rightOn.dataType} should be a TimestampType")
+    }
+
     new MergeAsOf(left, right, leftOn, rightOn, leftBy, rightBy, duration, allowExactMatches)
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -1194,18 +1194,18 @@ class Dataset[T] private[sql](
   }
 
   /**
-    * Merge As-Of Join with another 'DataFrame'.
-    *
-    * Different from other join functions, joining is with inexact time matching criteria.
-    *
-    * @param right Right side of the join operation.
-    * @param leftOn Field name to join on in left DataFrame.
-    * @param rightOn Field name to join on in right DataFrame.
-    * @param leftBy Field names to match on in the left DataFrame.
-    * @param rightBy Field names to match on in the right DataFrame.
-    * @param tolerance Long or TimeStamp, where the As-Of time difference within this range.
-    * @param allowExactMatches If True, allow matching with the same 'on' value.
-    */
+   * Merge As-Of Join with another 'DataFrame'.
+   *
+   * Different from other join functions, joining is with inexact time matching criteria.
+   *
+   * @param right Right side of the join operation.
+   * @param leftOn Field name to join on in left DataFrame.
+   * @param rightOn Field name to join on in right DataFrame.
+   * @param leftBy Field names to match on in the left DataFrame.
+   * @param rightBy Field names to match on in the right DataFrame.
+   * @param tolerance Long or TimeStamp, where the As-Of time difference within this range.
+   * @param allowExactMatches If True, allow matching with the same 'on' value.
+   */
   def mergeAsOf[U](
       right: Dataset[U],
       leftOn: Column,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/MergeAsOfJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/MergeAsOfJoinExec.scala
@@ -57,8 +57,6 @@ case class MergeAsOfJoinExec(
       Seq(rightBy, rightOn).map(SortOrder(_, Ascending)) :: Nil
   }
 
-  private val joinedRow = new JoinedRow()
-
   /**
    * Utility method to get output ordering for left or right side of the join.
    *
@@ -82,12 +80,13 @@ case class MergeAsOfJoinExec(
       val keyOrdering = newNaturalAscendingOrdering(leftBy.map(_.dataType))
       val resultProj: InternalRow => InternalRow = UnsafeProjection.create(output, output)
 
+      val leftGroupedIterator = GroupedIterator(leftIter, Seq(leftBy), left.output)
+      val rightGroupedIterator = GroupedIterator(rightIter, Seq(rightBy), right.output)
+
       new MergeAsOfIterator(
-        leftIter,
-        rightIter,
+        leftGroupedIterator,
+        rightGroupedIterator,
         resultProj,
-        leftBy,
-        rightBy,
         left.output,
         right.output,
         tolerance,
@@ -102,11 +101,9 @@ case class MergeAsOfJoinExec(
 
 
 private class MergeAsOfIterator(
-  leftIter: Iterator[InternalRow],
-  rightIter: Iterator[InternalRow],
+  leftGroupedIter: Iterator[(InternalRow, Iterator[InternalRow])],
+  rightGroupedIter: Iterator[(InternalRow, Iterator[InternalRow])],
   resultProj: InternalRow => InternalRow,
-  leftBy: Expression,
-  rightBy: Expression,
   leftOutput: Seq[Attribute],
   rightOutput: Seq[Attribute],
   tolerance: Long,
@@ -116,87 +113,72 @@ private class MergeAsOfIterator(
   keyOrdering: Ordering[InternalRow]
   ) extends RowIterator {
 
+  private[this] val leftGroupedIterator = leftGroupedIter
+  private[this] val rightGroupedIterator = rightGroupedIter
+
+  private[this] val leftOnProj = UnsafeProjection.create(Seq(leftOn), leftOutput)
+  private[this] val rightOnProj = UnsafeProjection.create(Seq(rightOn), rightOutput)
+
   protected[this] val joinedRow: JoinedRow = new JoinedRow()
   private[this] val rightNullRow = new GenericInternalRow(rightOutput.length)
-
-  private[this] val leftGroupedIterator = GroupedIterator(leftIter, Seq(leftBy), leftOutput)
-  private[this] val rightGroupedIterator = GroupedIterator(rightIter, Seq(rightBy), rightOutput)
-
-  private[this] var currLeft: (InternalRow, Iterator[InternalRow]) = _
   private[this] var currRight: (InternalRow, Iterator[InternalRow]) = _
+  if (rightGroupedIterator.hasNext) currRight = rightGroupedIterator.next()
 
   private[this] var resIter: Iterator[InternalRow] = _
 
-  override def advanceNext(): Boolean = {
-    if (findNextAsOfJoinRows()) {
-      true
-    } else {
-      false
-    }
-  }
+  override def advanceNext(): Boolean = findNextAsOfJoinRows()
 
   override def getRow: InternalRow = resIter.next()
 
   // --- Private methods --------------------------------------------------------------------------
 
   private def findNextAsOfJoinRows(): Boolean = {
-
     if (resIter != null && resIter.hasNext) {
       // resIter is either an Iterator returned from match_tolerance or an empty row projection
       true
     } else {
-      // resIter has exhausted its iterations; look for next iterator
-      if (!rightGroupedIterator.hasNext) {
-        // Consumed the entire right iterator
-        if (leftGroupedIterator.hasNext) {
-          resIter = leftGroupedIterator.next()._2.map(r => resultProj(joinedRow(r, rightNullRow)))
-          // There are groups in the left DF that are not in the right DF; return null projection
-          true
-        } else {
-          // There are no more groups in left or right DF in this partition; terminate
-          false
+      // resIter empty or exhausted - populate with an iterator
+      if (leftGroupedIterator.hasNext) {
+        // Should be called once per left group - will always return true
+        val currLeft = leftGroupedIterator.next()
+        if (currRight == null) {
+          // If there is no right group in the same partition, return null projection
+          resIter = currLeft._2.map(r => resultProj(joinedRow(r, rightNullRow)))
+          return true
         }
-      } else {
-        if (leftGroupedIterator.hasNext) {
-          currLeft = leftGroupedIterator.next()
-          currRight = rightGroupedIterator.next()
 
-          if (keyOrdering.compare(currLeft._1, currRight._1) == 0) {
-            // Matches current group, so call match_tolerance
-            resIter = match_tolerance(currLeft, currRight, tolerance, resultProj)
-            true
-          } else {
-            // There is a mismatch in the current group keys
-            // - either the right is ahead or left is ahead in terms of group ordering
-
-            // Because this is an As-Of Join, the left rows will always be returned so we assume
-            // the right rows are lagging and get the right rows up to speed (comp > 0)
-            var comp = 1
-            var empty = false
-            // While loop to get lagging right row up to speed or until it runs out
-            do {
-              if (rightGroupedIterator.hasNext) {
-                currRight = rightGroupedIterator.next()
-              } else {
-                empty = true
-              }
-              comp = keyOrdering.compare(currLeft._1, currRight._1)
-            } while (!empty && comp > 0)
-            // Breaks out of while loop if comp = 0 (the groups are matched; ideal) or
-            // comp < 0 (the right exceeds the left) [or the right runs out]
-            if (comp == 0) {
-              resIter = match_tolerance(currLeft, currRight, tolerance, resultProj)
-              // If both groups have the same key, proceed with the match tolerance
-              true
+        var comp = keyOrdering.compare(currLeft._1, currRight._1)
+        if (comp < 0) {
+          // Left group key is behind right group key - return null projection
+          resIter = currLeft._2.map(r => resultProj(joinedRow(r, rightNullRow)))
+        } else if (comp == 0) {
+          // Left group key is at right group key - call match tolerance
+          resIter = match_tolerance(currLeft, currRight, tolerance, resultProj)
+        } else {
+          // Left group key is ahead of right group key - catch right group up
+          var empty = false
+          // While loop to get lagging right row up to speed or until it runs out
+          do {
+            if (rightGroupedIterator.hasNext) {
+              currRight = rightGroupedIterator.next()
             } else {
-              // If the right row is empty or past the left group, then we ignore it
-              false
+              empty = true
             }
+            comp = keyOrdering.compare(currLeft._1, currRight._1)
+          } while (!empty && comp > 0)
+          // Breaks out of while loop if the groups are matched or the right runs out
+          if (empty || comp < 0) {
+            resIter = currLeft._2.map(r => resultProj(joinedRow(r, rightNullRow)))
+           } else {
+              // If both groups have the same key, proceed with match tolerance
+            resIter = match_tolerance(currLeft, currRight, tolerance, resultProj)
           }
-        } else {
-          // Key mismatch due to right keys that do not have a corresponding left key
-          false
         }
+        // A nonempty resIter will always be returned (1:1 left rows to output left rows)
+        true
+      } else {
+          // leftIter exhausted; key mismatch due to no more left key groups
+        false
       }
     }
   }
@@ -207,44 +189,41 @@ private class MergeAsOfIterator(
     currRight: (InternalRow, Iterator[InternalRow]),
     tolerance: Long,
     resultProj: InternalRow => InternalRow
-    ): Iterator[InternalRow] = {
-      var rHead = if (currRight._2.hasNext) {
-        currRight._2.next()
-      } else {
-        InternalRow.empty
-      }
-      var rPrev = rHead.copy()
+  ): Iterator[InternalRow] = {
+    // the current groups should be matching and the group should not be empty
+    assert(keyOrdering.compare(currLeft._1, currRight._1) == 0)
+    assert(currRight._2.hasNext)
 
-      currLeft._2.map(lHead => {
-        val leftKeyProj = UnsafeProjection.create(Seq(leftOn), leftOutput)
-        val rightKeyProj = UnsafeProjection.create(Seq(rightOn), rightOutput)
-        breakable {
-          // Use pointers to determine candidacy of the joining of right rows to left.
-          while (exactMatches && rightKeyProj(rHead).getLong(0) <= leftKeyProj(lHead).getLong(0)
-            || !exactMatches && rightKeyProj(rHead).getLong(0) < leftKeyProj(lHead).getLong(0)) {
-            var rHeadCopy = rHead.copy()
-            if (currRight._2.hasNext) {
-              rPrev = rHeadCopy.copy()
-              rHeadCopy = currRight._2.next()
-            } else {
-              break
-            }
+    val rHead = currRight._2.next()
+    var rPrev = rHead.copy()
+
+    currLeft._2.map(lHead => {
+      breakable {
+        // Use pointers to determine candidacy of the joining of right rows to left.
+        while (exactMatches && rightOnProj(rHead).getLong(0) <= leftOnProj(lHead).getLong(0)
+          || !exactMatches && rightOnProj(rHead).getLong(0) < leftOnProj(lHead).getLong(0)) {
+          var rHeadCopy = rHead.copy()
+          if (currRight._2.hasNext) {
+            rPrev = rHeadCopy.copy()
+            rHeadCopy = currRight._2.next()
+          } else {
+            break
           }
         }
-
-        // Obtain the left and right keys of the rows in consideration by projection.
-        var lProj = leftKeyProj(lHead).getLong(0)
-        var rProj = rightKeyProj(rPrev).getLong(0)
-        val toleranceCond = tolerance != Long.MaxValue && rProj + tolerance * 1000 < lProj
-
-        if (rPrev == InternalRow.empty ||
-          exactMatches && (rProj > lProj || toleranceCond) ||
-          !exactMatches && (rProj >= lProj || toleranceCond)) {
-          resultProj(joinedRow(lHead, new GenericInternalRow(rightOutput.length)))
-        } else {
-          resultProj(joinedRow(lHead, rPrev))
-        }
       }
-    )
+
+      // Obtain the left and right keys of the rows in consideration by projection.
+      val lProj = leftOnProj(lHead).getLong(0)
+      val rProj = rightOnProj(rPrev).getLong(0)
+      val toleranceCond = tolerance != Long.MaxValue && rProj + tolerance * 1000 < lProj
+
+      if (rPrev == InternalRow.empty ||
+        exactMatches && (rProj > lProj || toleranceCond) ||
+        !exactMatches && (rProj >= lProj || toleranceCond)) {
+        resultProj(joinedRow(lHead, new GenericInternalRow(rightOutput.length)))
+      } else {
+        resultProj(joinedRow(lHead, rPrev))
+      }
+    })
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/MergeAsOfJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/MergeAsOfJoinExec.scala
@@ -40,7 +40,7 @@ case class MergeAsOfJoinExec(
     leftBy: Expression,
     rightBy: Expression,
     tolerance: Long,
-    allowExactMatches: Boolean) extends BinaryExecNode {
+    exactMatches: Boolean) extends BinaryExecNode {
 
   override def output: Seq[Attribute] = left.output ++ right.output.map(_.withNullability((true)))
 
@@ -58,14 +58,12 @@ case class MergeAsOfJoinExec(
   }
 
   private val joinedRow = new JoinedRow()
-  private val emptyVal: Array[Any] = Array.fill(right.output.length)(null)
-  private def rDummy = InternalRow(emptyVal: _*)
 
   /**
-    * Utility method to get output ordering for left or right side of the join.
-    *
-    * Taken from [[SortMergeJoinExec]]
-    */
+   * Utility method to get output ordering for left or right side of the join.
+   *
+   * Taken from [[SortMergeJoinExec]]
+   */
   private def getKeyOrdering(keys: Seq[Expression], childOutputOrdering: Seq[SortOrder])
     : Seq[SortOrder] = {
     val requiredOrdering = keys.map(SortOrder(_, Ascending))
@@ -78,75 +76,175 @@ case class MergeAsOfJoinExec(
     }
   }
 
-  // Helper function performing the join using grouped iterators taking tolerance into account.
-  private def match_tolerance(
-      currLeft: (InternalRow, Iterator[InternalRow]),
-      currRight: (InternalRow, Iterator[InternalRow]),
-      tolerance: Long,
-      resultProj: InternalRow => InternalRow
-  ): Iterator[InternalRow] = {
-    var rHead = if (currRight._2.hasNext) {
-      currRight._2.next()
-    } else {
-      InternalRow.empty
-    }
-    var rPrev = rHead.copy()
-
-    currLeft._2.map(lHead => {
-      val leftKeyProj = UnsafeProjection.create(Seq(leftOn), left.output)
-      val rightKeyProj = UnsafeProjection.create(Seq(rightOn), right.output)
-      breakable {
-        // Use pointers to determine candidacy of the joining of right rows to left.
-        while (allowExactMatches && rightKeyProj(rHead).getLong(0) <= leftKeyProj(lHead).getLong(0)
-          || !allowExactMatches && rightKeyProj(rHead).getLong(0) < leftKeyProj(lHead).getLong(0)) {
-          var rHeadCopy = rHead.copy()
-          if (currRight._2.hasNext) {
-            rPrev = rHeadCopy.copy()
-            rHeadCopy = currRight._2.next()
-          } else {
-            break
-          }
-        }
-      }
-      // Obtain the left and right keys of the rows in consideration by projection.
-      var lProj = leftKeyProj(lHead).getLong(0)
-      var rProj = rightKeyProj(rPrev).getLong(0)
-      val toleranceCond = tolerance != Long.MaxValue && rProj + tolerance*1000 < lProj
-
-      if (rPrev == InternalRow.empty ||
-        allowExactMatches && (rProj > lProj || toleranceCond) ||
-        !allowExactMatches && (rProj >= lProj || toleranceCond)) {
-        resultProj(joinedRow(lHead, rDummy))
-      } else {
-        resultProj(joinedRow(lHead, rPrev))
-      }}
-    )
-  }
-
   protected override def doExecute(): RDD[InternalRow] = {
     // Zip the left and right plans to group by key.
     left.execute().zipPartitions(right.execute()) { (leftIter, rightIter) =>
+      val keyOrdering = newNaturalAscendingOrdering(leftBy.map(_.dataType))
       val resultProj: InternalRow => InternalRow = UnsafeProjection.create(output, output)
-      if (!leftIter.hasNext || !rightIter.hasNext) {
-        leftIter.map(r => resultProj(joinedRow(r, rDummy)))
-      } else {
-        val rightGroupedIterator =
-          GroupedIterator(rightIter, Seq(rightBy), right.output)
 
-        if (rightGroupedIterator.hasNext) {
-          var currRight = rightGroupedIterator.next()
-          val leftGroupedIterator =
-            GroupedIterator(leftIter, Seq(leftBy), left.output)
-          if (leftGroupedIterator.hasNext) {
-            var currLeft = leftGroupedIterator.next()
-            match_tolerance(currLeft, currRight, tolerance, resultProj)
+      new MergeAsOfIterator(
+        leftIter,
+        rightIter,
+        resultProj,
+        leftBy,
+        rightBy,
+        left.output,
+        right.output,
+        tolerance,
+        leftOn,
+        rightOn,
+        exactMatches,
+        keyOrdering
+      ).toScala
+    }
+  }
+}
+
+
+private class MergeAsOfIterator(
+  leftIter: Iterator[InternalRow],
+  rightIter: Iterator[InternalRow],
+  resultProj: InternalRow => InternalRow,
+  leftBy: Expression,
+  rightBy: Expression,
+  leftOutput: Seq[Attribute],
+  rightOutput: Seq[Attribute],
+  tolerance: Long,
+  leftOn: Expression,
+  rightOn: Expression,
+  exactMatches: Boolean,
+  keyOrdering: Ordering[InternalRow]
+  ) extends RowIterator {
+
+  protected[this] val joinedRow: JoinedRow = new JoinedRow()
+  private[this] val rightNullRow = new GenericInternalRow(rightOutput.length)
+
+  private[this] val leftGroupedIterator = GroupedIterator(leftIter, Seq(leftBy), leftOutput)
+  private[this] val rightGroupedIterator = GroupedIterator(rightIter, Seq(rightBy), rightOutput)
+
+  private[this] var currLeft: (InternalRow, Iterator[InternalRow]) = _
+  private[this] var currRight: (InternalRow, Iterator[InternalRow]) = _
+
+  private[this] var resIter: Iterator[InternalRow] = _
+
+  override def advanceNext(): Boolean = {
+    if (findNextAsOfJoinRows()) {
+      true
+    } else {
+      false
+    }
+  }
+
+  override def getRow: InternalRow = resIter.next()
+
+  // --- Private methods --------------------------------------------------------------------------
+
+  private def findNextAsOfJoinRows(): Boolean = {
+
+    if (resIter != null && resIter.hasNext) {
+      // resIter is either an Iterator returned from match_tolerance or an empty row projection
+      true
+    } else {
+      // resIter has exhausted its iterations; look for next iterator
+      if (!rightGroupedIterator.hasNext) {
+        // Consumed the entire right iterator
+        if (leftGroupedIterator.hasNext) {
+          resIter = leftGroupedIterator.next()._2.map(r => resultProj(joinedRow(r, rightNullRow)))
+          // There are groups in the left DF that are not in the right DF; return null projection
+          true
+        } else {
+          // There are no more groups in left or right DF in this partition; terminate
+          false
+        }
+      } else {
+        if (leftGroupedIterator.hasNext) {
+          currLeft = leftGroupedIterator.next()
+          currRight = rightGroupedIterator.next()
+
+          if (keyOrdering.compare(currLeft._1, currRight._1) == 0) {
+            // Matches current group, so call match_tolerance
+            resIter = match_tolerance(currLeft, currRight, tolerance, resultProj)
+            true
           } else {
-            Iterator.empty
+            // There is a mismatch in the current group keys
+            // - either the right is ahead or left is ahead in terms of group ordering
+
+            // Because this is an As-Of Join, the left rows will always be returned so we assume
+            // the right rows are lagging and get the right rows up to speed (comp > 0)
+            var comp = 1
+            var empty = false
+            // While loop to get lagging right row up to speed or until it runs out
+            do {
+              if (rightGroupedIterator.hasNext) {
+                currRight = rightGroupedIterator.next()
+              } else {
+                empty = true
+              }
+              comp = keyOrdering.compare(currLeft._1, currRight._1)
+            } while (!empty && comp > 0)
+            // Breaks out of while loop if comp = 0 (the groups are matched; ideal) or
+            // comp < 0 (the right exceeds the left) [or the right runs out]
+            if (comp == 0) {
+              resIter = match_tolerance(currLeft, currRight, tolerance, resultProj)
+              // If both groups have the same key, proceed with the match tolerance
+              true
+            } else {
+              // If the right row is empty or past the left group, then we ignore it
+              false
+            }
           }
         } else {
-          Iterator.empty
+          // Key mismatch due to right keys that do not have a corresponding left key
+          false
         }
       }
     }
+  }
+
+  // Helper function performing the join using grouped iterators taking tolerance into account.
+  private def match_tolerance(
+    currLeft: (InternalRow, Iterator[InternalRow]),
+    currRight: (InternalRow, Iterator[InternalRow]),
+    tolerance: Long,
+    resultProj: InternalRow => InternalRow
+    ): Iterator[InternalRow] = {
+      var rHead = if (currRight._2.hasNext) {
+        currRight._2.next()
+      } else {
+        InternalRow.empty
+      }
+      var rPrev = rHead.copy()
+
+      currLeft._2.map(lHead => {
+        val leftKeyProj = UnsafeProjection.create(Seq(leftOn), leftOutput)
+        val rightKeyProj = UnsafeProjection.create(Seq(rightOn), rightOutput)
+        breakable {
+          // Use pointers to determine candidacy of the joining of right rows to left.
+          while (exactMatches && rightKeyProj(rHead).getLong(0) <= leftKeyProj(lHead).getLong(0)
+            || !exactMatches && rightKeyProj(rHead).getLong(0) < leftKeyProj(lHead).getLong(0)) {
+            var rHeadCopy = rHead.copy()
+            if (currRight._2.hasNext) {
+              rPrev = rHeadCopy.copy()
+              rHeadCopy = currRight._2.next()
+            } else {
+              break
+            }
+          }
+        }
+
+        // Obtain the left and right keys of the rows in consideration by projection.
+        var lProj = leftKeyProj(lHead).getLong(0)
+        var rProj = rightKeyProj(rPrev).getLong(0)
+        val toleranceCond = tolerance != Long.MaxValue && rProj + tolerance * 1000 < lProj
+
+        if (rPrev == InternalRow.empty ||
+          exactMatches && (rProj > lProj || toleranceCond) ||
+          !exactMatches && (rProj >= lProj || toleranceCond)) {
+          resultProj(joinedRow(lHead, new GenericInternalRow(rightOutput.length)))
+        } else {
+          resultProj(joinedRow(lHead, rPrev))
+        }
+      }
+    )
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/MergeAsOfSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/MergeAsOfSuite.scala
@@ -192,6 +192,30 @@ class MergeAsOfSuite extends QueryTest with SharedSQLContext{
       ))
   }
 
+  test("merge_asof with non timestamp types") {
+    val quotes = Seq(
+      (1, "GOOG", 720.50, 720.93),
+      (2, "MSFT", 51.95, 51.96),
+      (3, "MSFT", 51.97, 51.98),
+      (4, "MSFT", 51.99, 52.00),
+      (5, "GOOG", 720.50, 720.93),
+      (6, "AAPL", 97.99, 98.01),
+      (7, "GOOG", 720.50, 720.88),
+      (8, "MSFT", 52.01, 52.03)
+    ).toDF("time", "ticker", "bid", "ask")
+
+    val trades = Seq(
+      (new Timestamp(23), "MSFT", 51.95, 75),
+      (new Timestamp(38), "MSFT", 51.95, 155),
+      (new Timestamp(48), "GOOG", 720.77, 100),
+      (new Timestamp(48), "GOOG", 720.92, 100),
+      (new Timestamp(48), "AAPL", 98.00, 100)
+    ).toDF("time", "ticker", "price", "quantity")
+
+    intercept[AnalysisException](trades.mergeAsOf(quotes, trades("time"), quotes("time"), trades("ticker"), quotes("ticker")))
+    intercept[AnalysisException](quotes.mergeAsOf(trades, quotes("time"), trades("time"), quotes("ticker"), trades("ticker")))
+  }
+
   test("self asof on larger dataset") {
     val df = Seq(
       (new Timestamp(100), 1, "a"),

--- a/sql/core/src/test/scala/org/apache/spark/sql/MergeAsOfSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/MergeAsOfSuite.scala
@@ -194,4 +194,42 @@ class MergeAsOfSuite extends QueryTest with SharedSQLContext{
         Row(new Timestamp(48), "AAPL", 98.0, 100, null, null)
       ))
   }
+
+  test("generated tests") {
+
+    val df = Seq(
+      (new Timestamp(100), 1, "a"),
+      (new Timestamp(101), 2, "a"),
+      (new Timestamp(102), 3, "a"),
+      (new Timestamp(103), 4, "a"),
+      (new Timestamp(104), 5, "a"),
+      (new Timestamp(105), 6, "a"),
+      (new Timestamp(106), 7, "a"),
+      (new Timestamp(107), 8, "a"),
+      (new Timestamp(108), 9, "a"),
+      (new Timestamp(109), 10, "a"),
+      (new Timestamp(110), 11, "a"),
+      (new Timestamp(111), 12, "a"),
+      (new Timestamp(112), 13, "a"),
+      (new Timestamp(113), 14, "a"),
+      (new Timestamp(114), 15, "a"),
+      (new Timestamp(115), 16, "a"),
+      (new Timestamp(116), 17, "a")
+    ).toDF("time", "id", "v")
+
+    val df1 = Seq(
+      (new Timestamp(100), 1, "b"),
+      (new Timestamp(101), 2, "b"),
+      (new Timestamp(102), 3, "b"),
+      (new Timestamp(103), 4, "b"),
+      (new Timestamp(104), 5, "b"),
+      (new Timestamp(105), 6, "b")
+    ).toDF("time", "id", "v2")
+
+    val res1 = df.mergeAsOf(df, df("time"), df("time"), df("id"), df("id"))
+    res1.show()
+    val res2 = df.mergeAsOf(df1, df("time"), df1("time"), df("id"), df1("id"))
+    res2.show()
+
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

## How was this patch tested?

Microbenchmark on generated test data over 1 year, a begin date of 2016/01/01, end date of 2017/01/01, timedelta of 30 minutes, begin hour of 9, end hour of 17, 50 keys and 5 values - a total of 23424000 rows. The total number of microseconds for a left join on 100 iterations on this generated data set is 1147572291.0, and the total number of microseconds for the implemented merge_asof join on 100 iterations over the same dataset is 1291802638.0, for a runtime of 1.1331415655308614x.

Please review https://spark.apache.org/contributing.html before opening a pull request.
