### PR TITLE
generated tests including naive implementation

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/MergeAsOfJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/MergeAsOfJoinExec.scala
@@ -204,7 +204,7 @@ private class MergeAsOfIterator(
     // The current groups should be matching and the group should not be empty.
     assert(currRightIter.hasNext)
     var rHead = currRightIter.next()
-    var rPrev = rHead
+    var rPrev = rHead.copy()
 
     currLeftIter.map(lHead => {
       var exit = false

--- a/sql/core/src/test/scala/org/apache/spark/sql/MergeAsOfSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/MergeAsOfSuite.scala
@@ -23,6 +23,8 @@ import org.apache.spark.sql.execution.joins._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSQLContext
 
+import scala.concurrent.duration.Duration
+
 class MergeAsOfSuite extends QueryTest with SharedSQLContext{
   import testImplicits._
 
@@ -497,5 +499,137 @@ class MergeAsOfSuite extends QueryTest with SharedSQLContext{
         Row(new Timestamp(104), 19, "c", null),
         Row(new Timestamp(105), 20, "c", null)
       ))
+  }
+
+  test("generated intervalized test") {
+    val seconds: Long = 1000
+    val minutes: Long = 60*seconds
+    val hours: Long = 60*minutes
+    val days: Long = 24*hours
+    val months: Long = 30*days
+    val years: Long = 12*months
+
+    val lData = genIntervalizedData(
+      "15min",
+      new Timestamp(46*years),
+      new Timestamp(46*years + months),
+      9,
+      17,
+      50,
+      1,
+      123,
+      0.5
+    )
+
+    var rData = genIntervalizedData(
+      "15min",
+      new Timestamp(46*years),
+      new Timestamp(46*years + 10*months),
+      9,
+      17,
+      100,
+      1,
+      456,
+      0.7
+    )
+
+    def test(
+      lData: DataFrame,
+      rData: DataFrame,
+      leftOn: Column,
+      rightOn: Column,
+      leftBy: Column,
+      rightBy: Column,
+      tolerance: Long = Long.MaxValue,
+      exactMatches: Boolean = true
+    ): Unit = {
+      val col = lData.columns.toList ++ rData.columns.map(c => "r"+c).filter(c => {c != "rtime" && c != "rid"}).toList
+      var res = lData
+      var expected = lData
+      if (tolerance == Long.MaxValue) {
+        res = lData.mergeAsOf(rData, leftOn, rightOn, leftBy, rightBy, "Inf", exactMatches).toDF(col: _*)
+        expected = naive(lData, rData, leftOn, rightOn, leftBy, rightBy, tolerance, exactMatches)
+      } else {
+        res = lData.mergeAsOf(rData, leftOn, rightOn, leftBy, rightBy, tolerance.toString+"ms", exactMatches).toDF(col: _*)
+        expected = naive(lData, rData, leftOn, rightOn, leftBy, rightBy, tolerance/1000, exactMatches)
+      }
+      assert(res.count() == expected.count())
+      checkAnswer(res, expected)
+    }
+
+    test(lData, rData, lData("time"), rData("time"), lData("id"), rData("id"), Long.MaxValue, false)
+  }
+
+  private def genIntervalizedData(
+    freq: String,
+    begin: Timestamp,
+    end: Timestamp,
+    beginHour: Int,
+    endHour: Int,
+    keys: Int,
+    values: Int,
+    seed: Long,
+    bias: Double
+  ): DataFrame = {
+    val frequency = Duration(freq).toSeconds
+    val delta = (end.getTime-begin.getTime)/1000
+    val dates = for (i <- spark.range(0, delta/frequency)) yield {begin.getTime/1000 + i*frequency}
+    var df = dates.toDF("time")
+    df = df.withColumn("ids", functions.array((0 to keys+1).map(functions.lit): _*))
+    df = df.withColumn("id", functions.explode(df.col("ids"))).drop("ids")
+    for (i <- 1 to values) {
+      df = df.withColumn(s"v$i", functions.rand(seed=seed)-0.5)
+    }
+    df = df.withColumn("time", functions.col("time").cast("timestamp"))
+    df = df.filter(functions.hour(df.col("time")) >= beginHour).filter(functions.hour(df.col("time")) < endHour)
+    df = df.filter(functions.rand(seed=seed) <= bias)
+
+    df
+  }
+
+  private def naive(
+    left: DataFrame,
+    right: DataFrame,
+    leftOn: Column,
+    rightOn: Column,
+    leftBy: Column,
+    rightBy: Column,
+    tolerance: Long = Long.MaxValue,
+    exactMatches: Boolean): DataFrame = {
+
+    val rCol = right.columns.map(c => "r"+c).toList
+    val newRight = right.toDF(rCol: _*)
+
+    val res = (tolerance, exactMatches) match {
+      case (Long.MaxValue, true) => left.join(
+        newRight,
+        left("id") === newRight("rid") && left("time") >= newRight("rtime"),
+        "left_outer"
+      )
+      case (Long.MaxValue, false) => left.join(
+        newRight,
+        left("id") === newRight("rid") && left("time") > newRight("rtime"),
+        "left_outer"
+      )
+      case(_, true) => left.join(
+        newRight,
+        left("id") === newRight("rid") && left("time") >= newRight("rtime") && left("time").cast("long") <= newRight("rtime").cast("long") + tolerance,
+        "left_outer"
+      )
+      case(_, false) => left.join(
+        newRight,
+        left("id") === newRight("rid") && left("time") > newRight("rtime") && left("time").cast("long") <= newRight("rtime").cast("long") + tolerance,
+        "left_outer"
+      )
+    }
+
+    var maxTime = res.groupBy("time", "id").agg(functions.max(newRight("rtime"))).sort("id")
+    maxTime = maxTime.toDF("time", "id", "maxtime")
+
+    var res2 = left.join(maxTime, Seq("time", "id"), joinType ="left")
+    res2 = res2.join(right, res2("id") === right("id") && res2("maxtime") === right("time"), joinType = "left")
+    val resCol = left.columns.toList ++ Seq("maxtime") ++ rCol
+
+    res2.toDF(resCol: _*).drop("maxtime").drop("rtime").drop("rid")
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/MergeAsOfSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/MergeAsOfSuite.scala
@@ -742,4 +742,5 @@ class MergeAsOfSuite extends QueryTest with SharedSQLContext{
 
     res2.toDF(resCol: _*).drop("maxtime").drop("rtime").drop("rid")
   }
+
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixed Merge AsOf's dependency on GroupIterator's hasNext method.

## How was this patch tested?

Generated test including naive implementation to compare merge_asof functionality.

On 100 iterations over 1 year data with 200 keys, the basic left join takes an average of 11506608.46 ms whereas the merge_asof takes an average of 11823816.44, for a performance factor of 1.031504259336628.